### PR TITLE
fix issue creating dupe WS conns

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bridg",
   "description": "Query your database from any JavaScript frontend",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "license": "ISC",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/generator/src/generator/client/clientDb.generate.ts
+++ b/packages/generator/src/generator/client/clientDb.generate.ts
@@ -88,8 +88,9 @@ const messageCallbacks: Record<string, (data: any) => void> = {};
 let ws: WebSocket | undefined;
 const getWebsocket = (): Promise<WebSocket> =>
   new Promise((resolve) => {
-    if (ws && ws.OPEN) resolve(ws);
-    else if (ws && ws.CONNECTING) {
+    if (ws && ws.readyState === ws.OPEN) {
+      resolve(ws);
+    } else if (ws && ws.readyState === ws.CONNECTING) {
       ws.addEventListener('open', () => ws && resolve(ws));
     } else {
       ws = new WebSocket(config.api);


### PR DESCRIPTION
This PR:

- fixes an issue creating multiple Websocket connections if multiple bridg queries are sent simultaneously on startup
   - correctly references `OPEN` and `CONNECTING` as static values (I thought they were bools 🤦‍♂️)