### PR TITLE
Update to new Pulse interface

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bridg",
   "description": "Query your database from any JavaScript frontend",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "license": "ISC",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/generator/src/generator/server/requestHandler.generate.ts
+++ b/packages/generator/src/generator/server/requestHandler.generate.ts
@@ -297,15 +297,14 @@ const buildSubscribeArgs = (queryArgs: {
   const where = queryArgs.where;
   const subscribeArgs = {};
   ['create', 'update', 'delete'].forEach((method) => {
-    const key = method === 'delete' ? 'before' : 'after';
-    let userQuery = queryArgs[method]?.[key] || queryArgs[method];
+    let userQuery = method === 'update' ? queryArgs[method]?.after : queryArgs[method];
     if (!userQuery && !applyRuleToAll) return;
     const queryWithRules = {
       ...userQuery,
       AND: [...(where?.AND || []), ...asArray(userQuery?.AND || [])],
     };
 
-    subscribeArgs[method] = { [key]: queryWithRules };
+    subscribeArgs[method] = method === 'update' ? { before: queryWithRules } : queryWithRules;
   });
   return subscribeArgs;
 };

--- a/packages/usage/__tests__/e2e/pulse.test.ts
+++ b/packages/usage/__tests__/e2e/pulse.test.ts
@@ -1,6 +1,6 @@
 import http from 'http';
 // unsure right now why this import method is necessary, but it breaks otherwise
-import { withPulse } from '../../node_modules/@prisma/extension-pulse/dist/cjs';
+import { withPulse } from '../../node_modules/@prisma/extension-pulse/dist/cjs/entry.node';
 import { handleRequest } from '../generated/bridg-pulse/server/request-handler';
 import { PrismaClient } from '../generated/prisma-pulse';
 
@@ -129,7 +129,7 @@ it('user defined filters working with where clauses', async () => {
   createPulseListener(
     {
       model: 'user',
-      args: { create: { name: 'fake' }, delete: { before: { name: 'john' } } },
+      args: { create: { name: 'fake' }, delete: { name: 'john' } },
       rules: { user: { find: { email: FAKE_USER_EMAIL } } },
     },
     (e) => eventsEmitted.push(e.action)
@@ -145,7 +145,7 @@ it('cannot run pulse queries against relational rules', async () => {
   const res = await createPulseListener(
     {
       model: 'user',
-      args: { create: { name: 'fake' }, delete: { before: { name: 'john' } } },
+      args: { create: { name: 'fake' }, delete: { name: 'john' } },
       rules: { user: { find: { email: FAKE_USER_EMAIL, blogs: { some: { title: 'hi' } } } } },
     },
     (e) => eventsEmitted.push(e.action)

--- a/packages/usage/__tests__/jest.polyfill.js
+++ b/packages/usage/__tests__/jest.polyfill.js
@@ -1,0 +1,2 @@
+// needed for pulse tests
+global.ReadableStream = require('web-streams-polyfill').ReadableStream;

--- a/packages/usage/jest.config.js
+++ b/packages/usage/jest.config.js
@@ -5,4 +5,5 @@ module.exports = {
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],
   modulePathIgnorePatterns: ['__helpers__/', '__fixtures__/'],
   testMatch: ['**/*.test.ts'],
+  setupFiles: ['./__tests__/jest.polyfill.js'],
 };

--- a/packages/usage/package.json
+++ b/packages/usage/package.json
@@ -24,10 +24,11 @@
     "prisma": "5.6.0",
     "ts-jest": "27.1.4",
     "ts-node": "^10.9.1",
-    "typescript": "4.5.2"
+    "typescript": "4.5.2",
+    "web-streams-polyfill": "^4.0.0"
   },
   "dependencies": {
     "@prisma/client": "5.6.0",
-    "@prisma/extension-pulse": "^0.1.8"
+    "@prisma/extension-pulse": "^1.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,8 @@ importers:
         specifier: 5.6.0
         version: 5.6.0(prisma@5.6.0)
       '@prisma/extension-pulse':
-        specifier: ^0.1.8
-        version: 0.1.8(@prisma/client@5.6.0)
+        specifier: ^1.0.0
+        version: 1.0.0(@prisma/client@5.6.0)
     devDependencies:
       '@jest/globals':
         specifier: ^29.6.2
@@ -103,6 +103,9 @@ importers:
       typescript:
         specifier: 4.5.2
         version: 4.5.2
+      web-streams-polyfill:
+        specifier: ^4.0.0
+        version: 4.0.0
 
   packages/usage/__tests__/generated/prisma: {}
 
@@ -1150,13 +1153,14 @@ packages:
     resolution: {integrity: sha512-Mt2q+GNJpU2vFn6kif24oRSBQv1KOkYaterQsi0k2/lA+dLvhRX6Lm26gon6PYHwUM8/h8KRgXIUMU0PCLB6bw==}
     requiresBuild: true
 
-  /@prisma/extension-pulse@0.1.8(@prisma/client@5.6.0):
-    resolution: {integrity: sha512-oWOldt1uJSuAVOws1T8QP13n8qH5agaIdcMfHK44/+VRJXAu/cKZt9y7iNx1K8FtgezCaszRXlLgkE5Yf4VDmQ==}
+  /@prisma/extension-pulse@1.0.0(@prisma/client@5.6.0):
+    resolution: {integrity: sha512-JWIn7zPZyt4+to47qEh75NyZigYR31dhU+S0U4UJezQqnSchH/Gj9NemA+DFsUlvtify+/jSVE2KW/SwxxzUDA==}
+    engines: {node: '>=18'}
     peerDependencies:
       '@prisma/client': '>=4.16.1'
     dependencies:
       '@prisma/client': 5.6.0(prisma@5.6.0)
-      ws: 8.14.2
+      ws: 8.16.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -5022,6 +5026,11 @@ packages:
       makeerror: 1.0.12
     dev: true
 
+  /web-streams-polyfill@4.0.0:
+    resolution: {integrity: sha512-0zJXHRAYEjM2tUfZ2DiSOHAa2aw1tisnnhU3ufD57R8iefL+DcdJyRBRyJpG+NUimDgbTI/lH+gAE1PAvV3Cgw==}
+    engines: {node: '>= 8'}
+    dev: true
+
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
     dev: true
@@ -5116,8 +5125,8 @@ packages:
         optional: true
     dev: true
 
-  /ws@8.14.2:
-    resolution: {integrity: sha512-wEBG1ftX4jcglPxgFCMJmZ2PLtSbJ2Peg6TmpJFTbe9GZYOQCDPdMYu/Tm0/bGZkw8paZnJY45J4K2PZrLYq8g==}
+  /ws@8.16.0:
+    resolution: {integrity: sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1


### PR DESCRIPTION
- Updates to use new pulse query structure
   - `create` no longer uses `after` property
   - `delete` no longer uses `before` property
- updates tests to use pulse v1
- updates tests to polyfill `ReadableStream` constructor (used by pulse)