### PR TITLE
Bridg 1.1.8 - fix where clause rules overwriting AND queries

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bridg",
   "description": "Query your database from any JavaScript frontend",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "license": "ISC",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/generator/src/generator/server/requestHandler.generate.ts
+++ b/packages/generator/src/generator/server/requestHandler.generate.ts
@@ -177,7 +177,7 @@ To fix this until issue is resolved: Change "\${model}" db rules to not rely on 
     } else {
       const rulesWhere = ruleWhereOrBool === true ? {} : ruleWhereOrBool;
       // Note: AND: [args.where, rulesWhere] breaks on findUnique, update, delete
-      args.where = { ...(args?.where || {}), AND: [rulesWhere] };
+      args.where = { ...(args?.where || {}), AND: [rulesWhere, ...(args?.where?.AND || []) ] };
     }
   }
   const modelRelations = MODEL_RELATION_MAP[model];

--- a/packages/usage/__tests__/integration/rules/rules.find.test.ts
+++ b/packages/usage/__tests__/integration/rules/rules.find.test.ts
@@ -144,3 +144,16 @@ it('Find rules work with nested relations', async () => {
   await querySucceeds(bridg.user.findUnique({ where: { id: testUser.id }, include }));
   await querySucceeds(bridg.user.findUniqueOrThrow({ where: { id: testUser.id }, include }));
 });
+
+it('Find rules work with AND', async () => {
+  setRules({ blog: { find: { id: testBlog2.id } } });
+  await querySucceeds(
+    bridg.blog.findMany({ where: { AND: [{ body: testBlog2.body }, { title: testBlog2.title }] } }),
+    1
+  );
+  await querySucceeds(
+    bridg.blog.findMany({ where: { AND: [{ body: testBlog2.body }, { title: testBlog1.title }] } }),
+    0
+  );
+  await querySucceeds(bridg.blog.findMany({ where: { AND: [{ title: testBlog1.title }] } }), 0);
+});


### PR DESCRIPTION
closes #55

- Fixes an issue where user's AND queries were overwritten if they had a where clause database rule
- Adds appropriate tests

The issue:

If a user had database rules like so:
```ts
 setRules({
    blog: {
      find: {
        published: true
      },
    },
  });
```

and they called bridg:
```ts
bridg.blog.findFirst({
   where: {
     someFilter: 1,
     AND: [
         {userId},
         {published: true}
      ]
   }
})
```

When executed, their rule would be placed in the `AND` array, but the user's `where.AND` would be lost entirely.

```ts
// bridg under the hood:
prima.blog.findFirst({
    someFilter: 1,
    AND: [
      {published: true}
    ]
})