### PR TITLE
Bridg v1.1.11  - support authorizing pulse events with relational rules

### DIFF
--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -1,7 +1,7 @@
 {
   "name": "bridg",
   "description": "Query your database from any JavaScript frontend",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "license": "ISC",
   "main": "index.js",
   "types": "index.d.ts",

--- a/packages/generator/src/generator/server/requestHandler.generate.ts
+++ b/packages/generator/src/generator/server/requestHandler.generate.ts
@@ -87,12 +87,7 @@ export const handleRequest = async (
         if (clauseHasRelation[event.action]) {
           const recordId = event.created?.id || event.after?.id || event.deleted?.id;
           const where = findFirstArgs[event.action];
-          const data = await db[model].findFirst({
-            where: {
-              ...where,
-              AND: [...(where.AND || []), { id: recordId }],
-            },
-          });
+          const data = await db[model].findFirst({ where: { ...where, id: recordId } });
           // if event does not satisfy full query with relations, do not send to client
           if (!data) continue;
         }


### PR DESCRIPTION
This PR:

- fixes issues with relational find rules working with pulse subscriptions

How it works:
- when executing pulse subscriptions if there are relational clauses (from .find rules), remove them from the query before creating pulse subscription
- when a pulse event comes in, if the query was cleaned of relations, rerun the entire query via `.findFirst`.  if there are no results, the event is not authorized, if there are, move along as normal and forward the event to the client